### PR TITLE
Move favorite control before name column

### DIFF
--- a/e10.html
+++ b/e10.html
@@ -157,6 +157,7 @@
         <table class="table">
           <thead>
             <tr>
+              <th class="station-favorite-heading" aria-label="Favorit"></th>
               <th>Name</th>
               <th>Distanz</th>
               <th>Tankzeit</th>
@@ -166,7 +167,7 @@
           </thead>
           <tbody id="stations">
             <tr>
-              <td colspan="5">Wir laden die Daten...</td>
+              <td colspan="6">Wir laden die Daten...</td>
             </tr>
           </tbody>
         </table>
@@ -485,7 +486,8 @@
             );
             return `
             <tr id="${s.id}" data-lat="${s.lat}" data-lng="${s.lng}" data-dist="${s.dist}">
-              <td data-label="Name"><span class="station-name-cell"><button class="fav" data-id="${s.id}" ${isSaved ? "disabled" : ""}>${isSaved ? "❤️" : "🤍"}</button><a href="${stationDetailsHref}">${formatStationName(s)}</a></span></td>
+              <td class="station-favorite-cell"><button class="fav" data-id="${s.id}" ${isSaved ? "disabled" : ""}>${isSaved ? "❤️" : "🤍"}</button></td>
+              <td data-label="Name"><a href="${stationDetailsHref}">${formatStationName(s)}</a></td>
               <td data-label="Distanz" data-distance-column="true">${TankzeitStationCatalog.formatDistanceKm(s.dist)}</td>
               <td data-label="Tankzeit" id="${s.id}-minimum">-</td>
               <td data-label="Preis">${livePricesAvailable ? `${s[FUEL]} €/l` : NO_LIVE_PRICE_TEXT}</td>
@@ -542,7 +544,7 @@
           );
           if (!stations.length) {
             stationsEl.innerHTML =
-              "<tr><td colspan='5'>Keine offenen Stationen gefunden.</td></tr>";
+              "<tr><td colspan='6'>Keine offenen Stationen gefunden.</td></tr>";
             setStatus("Keine Stationen im Umkreis.");
             return;
           }
@@ -557,7 +559,7 @@
               );
               if (!fallbackStations.length) {
                 stationsEl.innerHTML =
-                  "<tr><td colspan='5'>Keine Stationen im Umkreis gefunden.</td></tr>";
+                  "<tr><td colspan='6'>Keine Stationen im Umkreis gefunden.</td></tr>";
                 setStatus(
                   "Livepreise sind derzeit nicht verfügbar. Im lokalen Verzeichnis wurden keine Stationen im Umkreis gefunden.",
                 );
@@ -569,7 +571,7 @@
             } catch (fallbackErr) {
               console.warn("Local station fallback failed", fallbackErr);
               stationsEl.innerHTML =
-                "<tr><td colspan='5'>Livepreise und lokales Stationsverzeichnis sind derzeit nicht verfügbar.</td></tr>";
+                "<tr><td colspan='6'>Livepreise und lokales Stationsverzeichnis sind derzeit nicht verfügbar.</td></tr>";
               setStatus(
                 "Livepreise sind derzeit nicht verfügbar und das lokale Stationsverzeichnis konnte nicht geladen werden.",
                 "error",
@@ -579,7 +581,7 @@
           }
           const message =
             "Fehler beim Laden der Daten. Bitte später erneut versuchen.";
-          stationsEl.innerHTML = `<tr><td colspan='5'>${message}</td></tr>`;
+          stationsEl.innerHTML = `<tr><td colspan='6'>${message}</td></tr>`;
           setStatus(message, "error");
         }
       }

--- a/index.html
+++ b/index.html
@@ -161,6 +161,7 @@
         <table class="table">
           <thead>
             <tr>
+              <th class="station-favorite-heading" aria-label="Favorit"></th>
               <th>Name</th>
               <th>Distanz</th>
               <th>Tankzeit</th>
@@ -170,7 +171,7 @@
           </thead>
           <tbody id="stations">
             <tr>
-              <td colspan="5">Wir laden die Daten...</td>
+              <td colspan="6">Wir laden die Daten...</td>
             </tr>
           </tbody>
         </table>
@@ -489,7 +490,8 @@
             );
             return `
             <tr id="${s.id}" data-lat="${s.lat}" data-lng="${s.lng}" data-dist="${s.dist}">
-              <td data-label="Name"><span class="station-name-cell"><button class="fav" data-id="${s.id}" ${isSaved ? "disabled" : ""}>${isSaved ? "❤️" : "🤍"}</button><a href="${stationDetailsHref}">${formatStationName(s)}</a></span></td>
+              <td class="station-favorite-cell"><button class="fav" data-id="${s.id}" ${isSaved ? "disabled" : ""}>${isSaved ? "❤️" : "🤍"}</button></td>
+              <td data-label="Name"><a href="${stationDetailsHref}">${formatStationName(s)}</a></td>
               <td data-label="Distanz" data-distance-column="true">${TankzeitStationCatalog.formatDistanceKm(s.dist)}</td>
               <td data-label="Tankzeit" id="${s.id}-minimum">-</td>
               <td data-label="Preis">${livePricesAvailable ? `${s[FUEL]} €/l` : NO_LIVE_PRICE_TEXT}</td>
@@ -549,7 +551,7 @@
           );
           if (!stations.length) {
             stationsEl.innerHTML =
-              "<tr><td colspan='5'>Keine offenen Stationen gefunden.</td></tr>";
+              "<tr><td colspan='6'>Keine offenen Stationen gefunden.</td></tr>";
             setStatus("Keine Stationen im Umkreis.");
             return;
           }
@@ -564,7 +566,7 @@
               );
               if (!fallbackStations.length) {
                 stationsEl.innerHTML =
-                  "<tr><td colspan='5'>Keine Stationen im Umkreis gefunden.</td></tr>";
+                  "<tr><td colspan='6'>Keine Stationen im Umkreis gefunden.</td></tr>";
                 setStatus(
                   "Livepreise sind derzeit nicht verfügbar. Im lokalen Verzeichnis wurden keine Stationen im Umkreis gefunden.",
                 );
@@ -576,7 +578,7 @@
             } catch (fallbackErr) {
               console.warn("Local station fallback failed", fallbackErr);
               stationsEl.innerHTML =
-                "<tr><td colspan='5'>Livepreise und lokales Stationsverzeichnis sind derzeit nicht verfügbar.</td></tr>";
+                "<tr><td colspan='6'>Livepreise und lokales Stationsverzeichnis sind derzeit nicht verfügbar.</td></tr>";
               setStatus(
                 "Livepreise sind derzeit nicht verfügbar und das lokale Stationsverzeichnis konnte nicht geladen werden.",
                 "error",
@@ -586,7 +588,7 @@
           }
           const message =
             "Fehler beim Laden der Daten. Bitte später erneut versuchen.";
-          stationsEl.innerHTML = `<tr><td colspan='5'>${message}</td></tr>`;
+          stationsEl.innerHTML = `<tr><td colspan='6'>${message}</td></tr>`;
           setStatus(message, "error");
         }
       }

--- a/styles.css
+++ b/styles.css
@@ -480,16 +480,13 @@ p {
   color: var(--muted);
 }
 
+.station-favorite-heading,
 .station-favorite-cell {
-  width: 1%;
+  width: 44px;
+  min-width: 44px;
+  padding-right: 14px;
+  text-align: center;
   white-space: nowrap;
-}
-
-.station-name-cell {
-  display: inline-flex;
-  align-items: center;
-  gap: 8px;
-  flex-wrap: wrap;
 }
 
 .table a {


### PR DESCRIPTION
## Summary
- move the favorite button into its own narrow column before the Name column
- keep the Name header aligned with the station names
- add spacing to the favorite column so the button has room before the station name

## Validation
- inline script syntax check for `index.html` and `e10.html`
- checked table header order and row markup so the favorite cell appears before `data-label="Name"`
- verified no `Entfernung` column was reintroduced