### PR TITLE
[codex] Add manual location search

### DIFF
--- a/e10.html
+++ b/e10.html
@@ -63,12 +63,12 @@
     <title>Tankzeit.de: Beste Zeit für E10 finden und Geld sparen</title>
     <link rel="preconnect" href="https://fonts.googleapis.com" />
     <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin />
-    <link rel="preload" href="styles.css?v=20260409-app-promo-v18" as="style" />
+    <link rel="preload" href="styles.css?v=20260510-location-search" as="style" />
     <link
       href="https://fonts.googleapis.com/css2?family=Manrope:wght@400;600;700&amp;display=swap"
       rel="stylesheet"
     />
-    <link rel="stylesheet" href="styles.css?v=20260409-app-promo-v18" />
+    <link rel="stylesheet" href="styles.css?v=20260510-location-search" />
     <script type="application/ld+json">
       {
         "@context": "https://schema.org",
@@ -137,15 +137,26 @@
 
       <section class="hero" id="location-hint">
         <div class="tip">
-          <strong>Hinweis:</strong> Bitte Standortzugriff erlauben, damit wir
-          Tankstellen in deiner Nähe finden.
+          <strong>Standort:</strong> Suche per Ort oder Postleitzahl oder nutze
+          den Browser-Standort, um nahe Tankstellen zu finden.
         </div>
-        <div class="tip">
-          Falls der automatische Abruf nicht klappt, kannst du den Button als
-          Backup erneut verwenden.
-        </div>
+        <form class="location-search" id="location-search-form">
+          <label for="location-search-input">Ort oder PLZ</label>
+          <div class="location-search-row">
+            <input
+              id="location-search-input"
+              type="search"
+              inputmode="search"
+              autocomplete="postal-code"
+              placeholder="z. B. 10115 Berlin"
+            />
+            <button class="btn primary" id="location-search-btn" type="submit">
+              Suchen
+            </button>
+          </div>
+        </form>
         <div class="location-actions">
-          <button class="btn primary" id="location-request-btn" type="button">
+          <button class="btn" id="location-request-btn" type="button">
             Standort abrufen
           </button>
         </div>
@@ -167,7 +178,7 @@
           </thead>
           <tbody id="stations">
             <tr>
-              <td colspan="6">Wir laden die Daten...</td>
+              <td colspan="6">Bitte Standort abrufen oder Ort/PLZ eingeben.</td>
             </tr>
           </tbody>
         </table>
@@ -217,7 +228,7 @@
     </nav>
 
     <script src="app-stats.js"></script>
-    <script src="station-catalog.js"></script>
+    <script src="station-catalog.js?v=20260510-location-search"></script>
     <script>
       const DATA_BASE = "data2/";
       const FUEL = "e10";
@@ -232,10 +243,14 @@
       const stationsEl = document.getElementById("stations");
       const sortModeEl = document.getElementById("sort-mode");
       const locationRequestBtn = document.getElementById("location-request-btn");
+      const locationSearchForm = document.getElementById("location-search-form");
+      const locationSearchInput = document.getElementById("location-search-input");
+      const locationSearchBtn = document.getElementById("location-search-btn");
       const priceHeadingEl = document.getElementById("price-heading");
       const ids = JSON.parse(localStorage.getItem("ids")) || [];
       const fav = JSON.parse(localStorage.getItem("fav")) || [];
       const SORT_STORAGE_KEY = `tankzeit_sort_${FUEL}`;
+      const LOCATION_QUERY_STORAGE_KEY = `tankzeit_location_query_${FUEL}`;
       const LOCATION_OPTIONS = { enableHighAccuracy: false, maximumAge: 300000 };
       const LOCATION_DEADLINE_MS = 25000;
       let currentCenter = null;
@@ -250,6 +265,8 @@
           loadStations(currentCenter.lat, currentCenter.lng);
         }
       });
+      locationSearchInput.value =
+        localStorage.getItem(LOCATION_QUERY_STORAGE_KEY) || "";
 
       function escapeHtml(value) {
         return String(value ?? "")
@@ -324,6 +341,13 @@
           : "Standort abrufen";
       }
 
+      function setLocationSearchBusy(isBusy) {
+        if (!locationSearchBtn || !locationSearchInput) return;
+        locationSearchBtn.disabled = isBusy;
+        locationSearchInput.disabled = isBusy;
+        locationSearchBtn.textContent = isBusy ? "Sucht..." : "Suchen";
+      }
+
       function geoError(err) {
         clearLocationRequest();
         setLocationButtonBusy(false);
@@ -362,8 +386,6 @@
         clearLocationRequest();
         setLocationButtonBusy(false);
         clearStatus();
-        const hint = document.getElementById("location-hint");
-        if (hint) hint.style.display = "none";
         loadStations(position.coords.latitude, position.coords.longitude);
       }
 
@@ -395,6 +417,34 @@
         locationDeadlineId = window.setTimeout(() => {
           geoError({ code: 3, message: "Location request deadline exceeded." });
         }, LOCATION_DEADLINE_MS);
+      }
+
+      async function searchManualLocation(event) {
+        event.preventDefault();
+        const query = locationSearchInput.value.trim();
+        if (!query) {
+          setStatus("Bitte Ort oder Postleitzahl eingeben.", "error");
+          locationSearchInput.focus();
+          return;
+        }
+
+        clearLocationRequest();
+        setLocationButtonBusy(false);
+        setLocationSearchBusy(true);
+        setStatus("Ort wird gesucht...");
+        try {
+          const result = await TankzeitStationCatalog.geocodeLocationQuery(query);
+          localStorage.setItem(LOCATION_QUERY_STORAGE_KEY, query);
+          await loadStations(result.lat, result.lng);
+        } catch (err) {
+          console.warn("Location search failed", err);
+          setStatus(
+            err?.message || "Ortssuche fehlgeschlagen. Bitte erneut versuchen.",
+            "error",
+          );
+        } finally {
+          setLocationSearchBusy(false);
+        }
       }
 
       function isTankerkoenigRequest(url) {
@@ -534,6 +584,7 @@
 
       async function loadStations(lat, lng) {
         currentCenter = { lat, lng };
+        TankzeitStationCatalog.setDistanceCenter(lat, lng);
         setStatus("Stationen werden geladen...");
         const url = `https://creativecommons.tankerkoenig.de/json/list.php?rad=10&type=all&sort=dist&lat=${lat}&lng=${lng}&apikey=fe8673d1-47be-1156-77e4-040e06cb785c`;
         try {
@@ -587,8 +638,8 @@
       }
 
       setLivePriceAvailability(true);
+      locationSearchForm.addEventListener("submit", searchManualLocation);
       locationRequestBtn.addEventListener("click", requestLocation);
-      requestLocation();
     </script>
     <script src="app-install-promo.js?v=20260409-app-promo-v12"></script>
   </body>

--- a/index.html
+++ b/index.html
@@ -67,12 +67,12 @@
     <title>Tankzeit.de: Beste Tankzeit finden und Geld sparen</title>
     <link rel="preconnect" href="https://fonts.googleapis.com" />
     <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin />
-    <link rel="preload" href="styles.css?v=20260409-app-promo-v18" as="style" />
+    <link rel="preload" href="styles.css?v=20260510-location-search" as="style" />
     <link
       href="https://fonts.googleapis.com/css2?family=Manrope:wght@400;600;700&amp;display=swap"
       rel="stylesheet"
     />
-    <link rel="stylesheet" href="styles.css?v=20260409-app-promo-v18" />
+    <link rel="stylesheet" href="styles.css?v=20260510-location-search" />
     <script type="application/ld+json">
       {
         "@context": "https://schema.org",
@@ -141,15 +141,26 @@
 
       <section class="hero" id="location-hint">
         <div class="tip">
-          <strong>Hinweis:</strong> Wir brauchen deinen Standort, um nahe
-          Tankstellen zu finden. Bitte erlaube den Zugriff im Browser.
+          <strong>Standort:</strong> Suche per Ort oder Postleitzahl oder nutze
+          den Browser-Standort, um nahe Tankstellen zu finden.
         </div>
-        <div class="tip">
-          Falls der automatische Abruf nicht klappt, kannst du den Button als
-          Backup erneut verwenden.
-        </div>
+        <form class="location-search" id="location-search-form">
+          <label for="location-search-input">Ort oder PLZ</label>
+          <div class="location-search-row">
+            <input
+              id="location-search-input"
+              type="search"
+              inputmode="search"
+              autocomplete="postal-code"
+              placeholder="z. B. 10115 Berlin"
+            />
+            <button class="btn primary" id="location-search-btn" type="submit">
+              Suchen
+            </button>
+          </div>
+        </form>
         <div class="location-actions">
-          <button class="btn primary" id="location-request-btn" type="button">
+          <button class="btn" id="location-request-btn" type="button">
             Standort abrufen
           </button>
         </div>
@@ -171,7 +182,7 @@
           </thead>
           <tbody id="stations">
             <tr>
-              <td colspan="6">Wir laden die Daten...</td>
+              <td colspan="6">Bitte Standort abrufen oder Ort/PLZ eingeben.</td>
             </tr>
           </tbody>
         </table>
@@ -221,7 +232,7 @@
     </nav>
 
     <script src="app-stats.js"></script>
-    <script src="station-catalog.js"></script>
+    <script src="station-catalog.js?v=20260510-location-search"></script>
     <script>
       const DATA_BASE = "data2/";
       const FUEL = "diesel";
@@ -236,10 +247,14 @@
       const stationsEl = document.getElementById("stations");
       const sortModeEl = document.getElementById("sort-mode");
       const locationRequestBtn = document.getElementById("location-request-btn");
+      const locationSearchForm = document.getElementById("location-search-form");
+      const locationSearchInput = document.getElementById("location-search-input");
+      const locationSearchBtn = document.getElementById("location-search-btn");
       const priceHeadingEl = document.getElementById("price-heading");
       const ids = JSON.parse(localStorage.getItem("ids")) || [];
       const fav = JSON.parse(localStorage.getItem("fav")) || [];
       const SORT_STORAGE_KEY = `tankzeit_sort_${FUEL}`;
+      const LOCATION_QUERY_STORAGE_KEY = `tankzeit_location_query_${FUEL}`;
       const LOCATION_OPTIONS = { enableHighAccuracy: false, maximumAge: 300000 };
       const LOCATION_DEADLINE_MS = 25000;
       let currentCenter = null;
@@ -254,6 +269,8 @@
           loadStations(currentCenter.lat, currentCenter.lng);
         }
       });
+      locationSearchInput.value =
+        localStorage.getItem(LOCATION_QUERY_STORAGE_KEY) || "";
 
       function escapeHtml(value) {
         return String(value ?? "")
@@ -328,6 +345,13 @@
           : "Standort abrufen";
       }
 
+      function setLocationSearchBusy(isBusy) {
+        if (!locationSearchBtn || !locationSearchInput) return;
+        locationSearchBtn.disabled = isBusy;
+        locationSearchInput.disabled = isBusy;
+        locationSearchBtn.textContent = isBusy ? "Sucht..." : "Suchen";
+      }
+
       function geoError(err) {
         clearLocationRequest();
         setLocationButtonBusy(false);
@@ -366,8 +390,6 @@
         clearLocationRequest();
         setLocationButtonBusy(false);
         clearStatus();
-        const hint = document.getElementById("location-hint");
-        if (hint) hint.style.display = "none";
         loadStations(position.coords.latitude, position.coords.longitude);
       }
 
@@ -399,6 +421,34 @@
         locationDeadlineId = window.setTimeout(() => {
           geoError({ code: 3, message: "Location request deadline exceeded." });
         }, LOCATION_DEADLINE_MS);
+      }
+
+      async function searchManualLocation(event) {
+        event.preventDefault();
+        const query = locationSearchInput.value.trim();
+        if (!query) {
+          setStatus("Bitte Ort oder Postleitzahl eingeben.", "error");
+          locationSearchInput.focus();
+          return;
+        }
+
+        clearLocationRequest();
+        setLocationButtonBusy(false);
+        setLocationSearchBusy(true);
+        setStatus("Ort wird gesucht...");
+        try {
+          const result = await TankzeitStationCatalog.geocodeLocationQuery(query);
+          localStorage.setItem(LOCATION_QUERY_STORAGE_KEY, query);
+          await loadStations(result.lat, result.lng);
+        } catch (err) {
+          console.warn("Location search failed", err);
+          setStatus(
+            err?.message || "Ortssuche fehlgeschlagen. Bitte erneut versuchen.",
+            "error",
+          );
+        } finally {
+          setLocationSearchBusy(false);
+        }
       }
 
       function isTankerkoenigRequest(url) {
@@ -541,6 +591,7 @@
 
       async function loadStations(lat, lng) {
         currentCenter = { lat, lng };
+        TankzeitStationCatalog.setDistanceCenter(lat, lng);
         setStatus("Stationen werden geladen...");
         const url = `https://creativecommons.tankerkoenig.de/json/list.php?rad=10&type=all&sort=dist&lat=${lat}&lng=${lng}&apikey=fe8673d1-47be-1156-77e4-040e06cb785c`;
         try {
@@ -594,8 +645,8 @@
       }
 
       setLivePriceAvailability(true);
+      locationSearchForm.addEventListener("submit", searchManualLocation);
       locationRequestBtn.addEventListener("click", requestLocation);
-      requestLocation();
     </script>
     <script src="app-install-promo.js?v=20260409-app-promo-v12"></script>
   </body>

--- a/station-catalog.js
+++ b/station-catalog.js
@@ -1,14 +1,8 @@
 (function () {
   const STATIONS_URL = "data/stations.json";
   const DISTANCE_COLUMN_LABEL = "Distanz";
-  const DISTANCE_LOCATION_OPTIONS = {
-    enableHighAccuracy: false,
-    maximumAge: 300000,
-    timeout: 25000,
-  };
   let stationCatalogPromise = null;
   let distanceCenter = null;
-  let distanceRequestStarted = false;
   let distanceColumnObserver = null;
 
   function toFiniteNumber(value) {
@@ -144,32 +138,6 @@
     );
   }
 
-  function requestDistanceCenter() {
-    if (
-      distanceRequestStarted ||
-      distanceCenter ||
-      !navigator.geolocation ||
-      !stationTableBody()?.querySelector('td[data-label="Name"]')
-    ) {
-      return;
-    }
-
-    distanceRequestStarted = true;
-    navigator.geolocation.getCurrentPosition(
-      (position) => {
-        distanceCenter = {
-          lat: position.coords.latitude,
-          lng: position.coords.longitude,
-        };
-        updateDistanceColumn();
-      },
-      () => {
-        distanceRequestStarted = false;
-      },
-      DISTANCE_LOCATION_OPTIONS,
-    );
-  }
-
   function updateDistanceColumn() {
     const tbody = stationTableBody();
     if (!tbody) return;
@@ -181,7 +149,14 @@
         updateDistanceCell(row);
       }
     });
-    requestDistanceCenter();
+  }
+
+  function setDistanceCenter(lat, lng) {
+    const centerLat = toFiniteNumber(lat);
+    const centerLng = toFiniteNumber(lng);
+    if (!Number.isFinite(centerLat) || !Number.isFinite(centerLng)) return;
+    distanceCenter = { lat: centerLat, lng: centerLng };
+    updateDistanceColumn();
   }
 
   function installDistanceColumn() {
@@ -241,10 +216,65 @@
       .slice(0, limit);
   }
 
+  function locationLabelFromResult(result, fallback) {
+    const address = result?.address || {};
+    const city =
+      address.city ||
+      address.town ||
+      address.village ||
+      address.municipality ||
+      address.county;
+    const postcode = address.postcode;
+    if (postcode && city) return `${postcode} ${city}`;
+    return city || postcode || result?.display_name || fallback;
+  }
+
+  async function geocodeLocationQuery(query) {
+    const trimmedQuery = String(query || "").trim();
+    if (!trimmedQuery) {
+      throw new Error("Bitte Ort oder Postleitzahl eingeben.");
+    }
+
+    const params = new URLSearchParams({
+      q: trimmedQuery,
+      format: "jsonv2",
+      addressdetails: "1",
+      countrycodes: "de",
+      limit: "1",
+      "accept-language": "de",
+    });
+    const response = await fetch(
+      `https://nominatim.openstreetmap.org/search?${params.toString()}`,
+    );
+    if (!response.ok) {
+      throw new Error("Die Ortssuche ist gerade nicht erreichbar.");
+    }
+
+    const results = await response.json();
+    const match = Array.isArray(results)
+      ? results.find(
+          (result) =>
+            toFiniteNumber(result.lat) !== null &&
+            toFiniteNumber(result.lon) !== null,
+        )
+      : null;
+    if (!match) {
+      throw new Error("Kein Ort gefunden. Bitte Ort oder Postleitzahl prüfen.");
+    }
+
+    return {
+      lat: toFiniteNumber(match.lat),
+      lng: toFiniteNumber(match.lon),
+      label: locationLabelFromResult(match, trimmedQuery),
+    };
+  }
+
   window.TankzeitStationCatalog = {
     findNearbyStations,
     formatDistanceKm,
+    geocodeLocationQuery,
     loadCatalog,
+    setDistanceCenter,
   };
 
   if (document.readyState === "loading") {

--- a/styles.css
+++ b/styles.css
@@ -267,6 +267,53 @@ p {
   padding-top: 4px;
 }
 
+.location-search {
+  display: grid;
+  gap: 8px;
+}
+
+.location-search label {
+  color: var(--muted);
+  font-size: 0.82rem;
+  font-weight: 700;
+}
+
+.location-search-row {
+  display: grid;
+  grid-template-columns: minmax(180px, 1fr) auto;
+  gap: 10px;
+  align-items: center;
+}
+
+.location-search input {
+  width: 100%;
+  min-height: 44px;
+  border: 1px solid rgba(128, 128, 128, 0.3);
+  border-radius: 999px;
+  padding: 10px 16px;
+  font: inherit;
+  font-size: 0.95rem;
+  background: var(--card);
+  color: var(--ink);
+  box-shadow: var(--shadow-sm);
+}
+
+.location-search input:disabled {
+  cursor: wait;
+  opacity: 0.7;
+}
+
+@media (max-width: 520px) {
+  .location-search-row {
+    grid-template-columns: 1fr;
+  }
+
+  .location-search-row .btn,
+  .location-actions .btn {
+    width: 100%;
+  }
+}
+
 /* ========== App Install Promo ========== */
 .app-install-promo {
   margin: 0 0 12px;


### PR DESCRIPTION
## Summary
- add an Ort/PLZ search form above the Diesel and E10 station tables
- keep the browser location button as an explicit option instead of auto-requesting location on page load
- geocode manual searches through OpenStreetMap/Nominatim and reuse the existing station loading and distance sorting path
- prevent the shared distance helper from triggering its own background geolocation request

## Validation
- `node --check station-catalog.js`
- inline script syntax check for `index.html` and `e10.html`
- static checks for new form/cache-busted assets and no automatic `requestLocation()` call
- `git diff --cached --check`